### PR TITLE
Fix catch by value build error

### DIFF
--- a/tester/main.cpp
+++ b/tester/main.cpp
@@ -106,7 +106,7 @@ int main(int nargs, char **pargs) {
     } else {
       assert_exception(false, "Unknown tester mode");
     }
-  } catch (AssertException) {
+  } catch (const AssertException &) {
     std::cout << "Test failed." << std::endl;
     return -1;
   }


### PR DESCRIPTION
## Summary
- fix compiler error due to catching AssertException by value

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Release ..`
- `make -j$(nproc)`
- `ctest`