### PR TITLE
Add implementation filter for bst tester

### DIFF
--- a/tester/binary_search_tree/tester.cpp
+++ b/tester/binary_search_tree/tester.cpp
@@ -19,7 +19,7 @@
 namespace tester {
 namespace bst {
 
-bool test(TestType test_type) {
+bool test(TestType test_type, std::string_view implementation_filter) {
   switch (test_type) {
     case TestType::kSmall: {
       using Scenarios = std::tuple<
@@ -69,7 +69,7 @@ bool test(TestType test_type) {
           impl::HKT_HPF_Treap, impl::HKT_HPT_Treap, impl::HKF_HPF_Unbalanced,
           impl::HKF_HPT_Unbalanced, impl::HKT_HPF_Unbalanced,
           impl::HKT_HPT_Unbalanced, impl::HKF_HPF_WAVL, impl::HKF_HPT_WAVL,
-          impl::HKT_HPF_WAVL, impl::HKT_HPT_WAVL>(1000);
+          impl::HKT_HPF_WAVL, impl::HKT_HPT_WAVL>(1000, implementation_filter);
     }
 
     case TestType::kBase: {
@@ -97,7 +97,8 @@ bool test(TestType test_type) {
           impl::HKT_HPT_Scapegoat, impl::HKF_HPT_Splay, impl::HKT_HPT_Splay,
           impl::HKF_HPF_Treap, impl::HKF_HPT_Treap, impl::HKT_HPF_Treap,
           impl::HKT_HPT_Treap, impl::HKF_HPF_WAVL, impl::HKF_HPT_WAVL,
-          impl::HKT_HPF_WAVL, impl::HKT_HPT_WAVL>(100000);
+          impl::HKT_HPF_WAVL, impl::HKT_HPT_WAVL>(100000,
+                                                  implementation_filter);
     }
 
     case TestType::kExpensiveData: {
@@ -117,7 +118,8 @@ bool test(TestType test_type) {
           impl::HKT_HPT_Scapegoat, impl::HKF_HPT_Splay, impl::HKT_HPT_Splay,
           impl::HKF_HPF_Treap, impl::HKF_HPT_Treap, impl::HKT_HPF_Treap,
           impl::HKT_HPT_Treap, impl::HKF_HPF_WAVL, impl::HKF_HPT_WAVL,
-          impl::HKT_HPF_WAVL, impl::HKT_HPT_WAVL>(100000);
+          impl::HKT_HPF_WAVL, impl::HKT_HPT_WAVL>(100000,
+                                                  implementation_filter);
     }
 
     default:

--- a/tester/binary_search_tree/tester.h
+++ b/tester/binary_search_tree/tester.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <string_view>
+
 namespace tester {
 namespace bst {
 
 enum class TestType { kSmall, kBase, kExpensiveData, kSegment, kJoinSplit };
 
-bool test(TestType test_type);
+bool test(TestType test_type, std::string_view implementation_filter = {});
 
 }  // namespace bst
 }  // namespace tester

--- a/tester/main.cpp
+++ b/tester/main.cpp
@@ -8,8 +8,10 @@
 
 int main(int nargs, char **pargs) {
   std::string tester_mode;
+  std::string implementation_filter;
   if (nargs >= 2) {
     tester_mode = pargs[1];
+    if (nargs >= 3) implementation_filter = pargs[2];
   } else {
     std::cout << "Input tester mode to run:" << std::endl;
     std::cin >> tester_mode;
@@ -19,12 +21,14 @@ int main(int nargs, char **pargs) {
     if (tester_mode == "binary_search_tree") {
       assert_exception(TestBinarySearchTree(false));
     } else if (tester_mode == "bst_base") {
-      assert_exception(tester::bst::test(tester::bst::TestType::kBase));
+      assert_exception(tester::bst::test(tester::bst::TestType::kBase,
+                                         implementation_filter));
     } else if (tester_mode == "bst_expensive_data") {
-      assert_exception(
-          tester::bst::test(tester::bst::TestType::kExpensiveData));
+      assert_exception(tester::bst::test(tester::bst::TestType::kExpensiveData,
+                                         implementation_filter));
     } else if (tester_mode == "bst_small") {
-      assert_exception(tester::bst::test(tester::bst::TestType::kSmall));
+      assert_exception(tester::bst::test(tester::bst::TestType::kSmall,
+                                         implementation_filter));
     } else if (tester_mode == "bst_split_join") {
       assert_exception(TestBinarySearchTreeSplitJoin(false));
     } else if (tester_mode == "convergent") {


### PR DESCRIPTION
## Summary
- allow specifying a single BST implementation to test
- plumb optional filter through tester CLI and binary search tree test harness

## Testing
- `mkdir -p debug && cd debug && cmake -DCMAKE_BUILD_TYPE=Debug .. && make`
- `mkdir -p release && cd release && cmake -DCMAKE_BUILD_TYPE=Release .. && make && ctest`
- `./release/build/tester bst_base`
- `./release/build/tester bst_base hpt_splay`

------
https://chatgpt.com/codex/tasks/task_e_6896b378047483268fd5cf14a6804bb4