### PR TITLE
Add split/join scenarios for implicit trees

### DIFF
--- a/common/binary_search_tree/red_black_tree.h
+++ b/common/binary_search_tree/red_black_tree.h
@@ -1118,7 +1118,7 @@ class RedBlackTree
     } else {
       split_at_impl_internal(r, bh, lsize - left_size - 1, m, bhm, output_r,
                              bhr);
-      std::tie(output_l, bhl) = join3_impl_internal(l, root, m, bhl, bhm);
+      std::tie(output_l, bhl) = join3_impl_internal(l, root, m, bh, bhm);
     }
   }
 };

--- a/tester/binary_search_tree/scenario/split_join_add_as.h
+++ b/tester/binary_search_tree/scenario/split_join_add_as.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "tester/binary_search_tree/data.h"
+#include "tester/binary_search_tree/scenario/base.h"
+#include "tester/binary_search_tree/scenario/result.h"
+#include "tester/binary_search_tree/utils/verify_parent_links.h"
+#include "tester/hash_combine.h"
+
+#include "common/assert_exception.h"
+#include "common/base.h"
+#include "common/binary_search_tree/deferred/add_arithmetic_sequence.h"
+#include "common/binary_search_tree/subtree_data/size.h"
+#include "common/binary_search_tree/subtree_data/sum.h"
+#include "common/modular.h"
+#include "common/template.h"
+#include "common/timer.h"
+
+#include <chrono>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace tester {
+namespace bst {
+namespace scenario {
+
+template <DataType data_type>
+class SplitJoinAddAS : public Base<SplitJoinAddAS<data_type>> {
+ public:
+  static constexpr bool requires_key = false;
+  static constexpr bool requires_split = true;
+  static constexpr bool requires_join = true;
+
+  using Data = ModularDefault;
+  using Key = int64_t;
+  using Aggregator = ::bst::subtree_data::Sum<Data>;
+  using AggregatorsTuple = std::tuple<::bst::subtree_data::Size, Aggregator>;
+  using DeferredTuple =
+      std::tuple<::bst::deferred::AddArithmeticSequence<Data>>;
+
+  static constexpr std::string id() {
+    return std::string("split_join_add_as @ ") + get_name(data_type);
+  }
+
+  template <bool extra_checks, template <typename, typename, typename,
+                                         typename> class TImplementation>
+  static std::pair<size_t, std::chrono::nanoseconds> run_impl(
+      size_t size, std::string& implementation_id) {
+    using Implementation =
+        TImplementation<Data, Key, AggregatorsTuple, DeferredTuple>;
+    using Tree = typename Implementation::TreeType;
+
+    size /= 5;  // Adjust size because of expensive updates
+    implementation_id = Implementation::id();
+    const auto& lsizes = get_data_int64(data_type, size);
+    Tree tree(size);
+
+    Timer timer;
+    timer.start();
+    size_t hash = 0;
+
+    auto root = tree.build(std::vector<Data>(size));
+    if constexpr (extra_checks) {
+      assert_exception(root, "Root is null");
+      assert_exception(::bst::subtree_data::size(root) == size,
+                       "Root size is not the same as the size of the tree");
+      if constexpr (Tree::has_parent)
+        assert_exception(verify_parent_links(root),
+                         "Parent links are not valid");
+    }
+    hash_combine(hash, ::bst::subtree_data::size(root));
+
+    for (auto lsize_raw : lsizes) {
+      const size_t lsize = static_cast<size_t>(lsize_raw % (size + 1));
+      typename Tree::NodeType *l = nullptr, *r = nullptr;
+      Tree::split_at(root, lsize, l, r);
+      ::bst::deferred::add_arithmetic_sequence(l, Data(0), Data(1));
+      root = Tree::join(r, l);
+      if constexpr (extra_checks) {
+        assert_exception(::bst::subtree_data::size(root) == size,
+                         "Root size is not the same as the size of the tree");
+      }
+      hash_combine(hash, Aggregator::get(root).Get());
+    }
+
+    tree.release_tree(root);
+    if constexpr (extra_checks)
+      assert_exception(tree.used() == 0, "Memory usage is not 0");
+    hash_combine(hash, tree.used());
+
+    timer.stop();
+
+    return {hash, timer.get_duration()};
+  }
+};
+
+}  // namespace scenario
+}  // namespace bst
+}  // namespace tester

--- a/tester/binary_search_tree/scenario/split_join_add_each.h
+++ b/tester/binary_search_tree/scenario/split_join_add_each.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "tester/binary_search_tree/data.h"
+#include "tester/binary_search_tree/scenario/base.h"
+#include "tester/binary_search_tree/scenario/result.h"
+#include "tester/binary_search_tree/utils/verify_parent_links.h"
+#include "tester/hash_combine.h"
+
+#include "common/assert_exception.h"
+#include "common/base.h"
+#include "common/binary_search_tree/deferred/add_each.h"
+#include "common/binary_search_tree/subtree_data/size.h"
+#include "common/binary_search_tree/subtree_data/sum.h"
+#include "common/template.h"
+#include "common/timer.h"
+
+#include <chrono>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace tester {
+namespace bst {
+namespace scenario {
+
+template <DataType data_type>
+class SplitJoinAddEach : public Base<SplitJoinAddEach<data_type>> {
+ public:
+  static constexpr bool requires_key = false;
+  static constexpr bool requires_split = true;
+  static constexpr bool requires_join = true;
+
+  using Data = int64_t;
+  using Key = int64_t;
+  using Aggregator = ::bst::subtree_data::Sum<Data>;
+  using AggregatorsTuple = std::tuple<::bst::subtree_data::Size, Aggregator>;
+  using DeferredTuple = std::tuple<::bst::deferred::AddEach<Data>>;
+
+  static constexpr std::string id() {
+    return std::string("split_join_add_each @ ") + get_name(data_type);
+  }
+
+  template <bool extra_checks, template <typename, typename, typename,
+                                         typename> class TImplementation>
+  static std::pair<size_t, std::chrono::nanoseconds> run_impl(
+      size_t size, std::string& implementation_id) {
+    using Implementation =
+        TImplementation<Data, Key, AggregatorsTuple, DeferredTuple>;
+    using Tree = typename Implementation::TreeType;
+
+    implementation_id = Implementation::id();
+    const auto& lsizes = get_data_int64(data_type, size);
+    Tree tree(size);
+
+    Timer timer;
+    timer.start();
+    size_t hash = 0;
+
+    auto root = tree.build(std::vector<Data>(size, Data(0)));
+    if constexpr (extra_checks) {
+      assert_exception(root, "Root is null");
+      assert_exception(::bst::subtree_data::size(root) == size,
+                       "Root size is not the same as the size of the tree");
+      if constexpr (Tree::has_parent)
+        assert_exception(verify_parent_links(root),
+                         "Parent links are not valid");
+    }
+    hash_combine(hash, ::bst::subtree_data::size(root));
+
+    for (auto lsize_raw : lsizes) {
+      const size_t lsize = static_cast<size_t>(lsize_raw % (size + 1));
+      typename Tree::NodeType *l = nullptr, *r = nullptr;
+      Tree::split_at(root, lsize, l, r);
+      ::bst::deferred::add_to_each(l, Data(1));
+      root = Tree::join(r, l);
+      if constexpr (extra_checks) {
+        assert_exception(::bst::subtree_data::size(root) == size,
+                         "Root size is not the same as the size of the tree");
+      }
+      hash_combine(hash, Aggregator::get(root));
+    }
+
+    tree.release_tree(root);
+    if constexpr (extra_checks)
+      assert_exception(tree.used() == 0, "Memory usage is not 0");
+    hash_combine(hash, tree.used());
+
+    timer.stop();
+
+    return {hash, timer.get_duration()};
+  }
+};
+
+}  // namespace scenario
+}  // namespace bst
+}  // namespace tester

--- a/tester/binary_search_tree/tester.cpp
+++ b/tester/binary_search_tree/tester.cpp
@@ -15,6 +15,8 @@
 #include "tester/binary_search_tree/scenario/insert_remove_node.h"
 #include "tester/binary_search_tree/scenario/insert_remove_node_add_as.h"
 #include "tester/binary_search_tree/scenario/insert_remove_node_add_each.h"
+#include "tester/binary_search_tree/scenario/split_join_add_as.h"
+#include "tester/binary_search_tree/scenario/split_join_add_each.h"
 
 namespace tester {
 namespace bst {
@@ -55,7 +57,9 @@ bool test(TestType test_type) {
           scenario::InsertRemoveNodeAddAS<DataType::kReverse>,
           scenario::InsertRemoveNodeAddAS<DataType::kShuffled>,
           scenario::InsertRemoveNodeAddAS<DataType::kShuffledDuplicates>,
-          scenario::InsertAtRemoveAtAddAS<DataType::kRandom>>;
+          scenario::InsertAtRemoveAtAddAS<DataType::kRandom>,
+          scenario::SplitJoinAddEach<DataType::kRandom>,
+          scenario::SplitJoinAddAS<DataType::kRandom>>;
 
       return run_each<
           true, Scenarios, impl::HKF_HPF_AVL, impl::HKF_HPT_AVL,
@@ -86,7 +90,8 @@ bool test(TestType test_type) {
                      scenario::BuildAddEach<DataType::kShuffledDuplicates>,
                      scenario::InsertRemoveAddEach<DataType::kIncreasing>,
                      scenario::InsertRemoveAddEach<DataType::kReverse>,
-                     scenario::InsertRemoveAddEach<DataType::kShuffled>>;
+                     scenario::InsertRemoveAddEach<DataType::kShuffled>,
+                     scenario::SplitJoinAddEach<DataType::kRandom>>;
 
       return run_each<
           false, Scenarios, impl::HKF_HPF_AVL, impl::HKF_HPT_AVL,
@@ -106,7 +111,8 @@ bool test(TestType test_type) {
                      scenario::BuildAddAS<DataType::kShuffledDuplicates>,
                      scenario::InsertRemoveAddAS<DataType::kIncreasing>,
                      scenario::InsertRemoveAddAS<DataType::kReverse>,
-                     scenario::InsertRemoveAddAS<DataType::kShuffled>>;
+                     scenario::InsertRemoveAddAS<DataType::kShuffled>,
+                     scenario::SplitJoinAddAS<DataType::kRandom>>;
 
       return run_each<
           false, Scenarios, impl::HKF_HPF_AVL, impl::HKF_HPT_AVL,


### PR DESCRIPTION
## Summary
- use random split sizes in split/join implicit scenarios
- fix RedBlackTree split_at black-height bookkeeping
- include split/join scenarios in tester with random data

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug ..`
- `make`
- `cmake -DCMAKE_BUILD_TYPE=Release ..`
- `make`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_6896b19ceddc8326927416a33bab0f1d