### PR TITLE
Add split/join insert-remove scenario using random duplicates

### DIFF
--- a/tester/binary_search_tree/data.cpp
+++ b/tester/binary_search_tree/data.cpp
@@ -92,7 +92,7 @@ std::unordered_map<unsigned, std::vector<int64_t>> random_dups_data;
         data.resize(size);
         size_t seed = size;
         for (size_t i = 0; i < size; i += 2) {
-          data[2 * i] = data[2 * i + 1] = hash_combine(seed, i);
+          data[i] = data[i + 1] = hash_combine(seed, i);
         }
         nvector::Shuffle(data);
       }

--- a/tester/binary_search_tree/scenario/split_join_insert_remove.h
+++ b/tester/binary_search_tree/scenario/split_join_insert_remove.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "tester/binary_search_tree/data.h"
+#include "tester/binary_search_tree/scenario/base.h"
+#include "tester/binary_search_tree/scenario/result.h"
+#include "tester/hash_combine.h"
+
+#include "common/assert_exception.h"
+#include "common/base.h"
+#include "common/binary_search_tree/auto/find.h"
+#include "common/binary_search_tree/deferred/add_each_key.h"
+#include "common/binary_search_tree/subtree_data/size.h"
+#include "common/binary_search_tree/subtree_data/sum_keys.h"
+#include "common/template.h"
+#include "common/timer.h"
+
+#include <chrono>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace tester {
+namespace bst {
+namespace scenario {
+
+template <DataType data_type>
+class SplitJoinInsertRemove : public Base<SplitJoinInsertRemove<data_type>> {
+ public:
+  static constexpr bool requires_key = true;
+  static constexpr bool requires_insert = true;
+  static constexpr bool requires_remove = true;
+  static constexpr bool requires_split = true;
+  static constexpr bool requires_join = true;
+
+  using Data = int64_t;
+  using Key = int64_t;
+  using Aggregator = ::bst::subtree_data::SumKeys<Key>;
+  using AggregatorsTuple = std::tuple<::bst::subtree_data::Size, Aggregator>;
+  using DeferredTuple = std::tuple<::bst::deferred::AddEachKey<Key>>;
+
+  static constexpr std::string id() {
+    return std::string("split_join_insert_remove @ ") + get_name(data_type);
+  }
+
+  template <bool extra_checks, template <typename, typename, typename,
+                                         typename> class TImplementation>
+  static std::pair<size_t, std::chrono::nanoseconds> run_impl(
+      size_t size, std::string& implementation_id) {
+    using Implementation =
+        TImplementation<Data, Key, AggregatorsTuple, DeferredTuple>;
+    using Tree = typename Implementation::TreeType;
+    using Node = typename Tree::NodeType;
+
+    implementation_id = Implementation::id();
+    const auto& values = get_data_int64(data_type, size);
+    Tree tree(size);
+
+    Timer timer;
+    timer.start();
+    size_t hash = 0;
+    Node* root = nullptr;
+    Key shift = 0;
+    const Key max_key = Key(1) << 30;
+
+    for (auto value : values) {
+      Key key = value + shift;
+      key %= max_key;
+      if (key < 0) key += max_key;
+      Node* node = ::bst::auto_::find<Tree>(root, key);
+      if (node) {
+        if constexpr (extra_checks)
+          assert_exception(node->data == value, "Node value mismatch");
+        root = tree.remove_and_release(root, key);
+      } else {
+        root = tree.insert_new(root, value, key);
+      }
+
+      Key threshold = value % max_key;
+      if (threshold < 0) threshold += max_key;
+      Node *l = nullptr, *r = nullptr;
+      Tree::split(root, threshold, l, r);
+      ::bst::deferred::add_to_each_key(l, max_key - threshold);
+      ::bst::deferred::add_to_each_key(r, Key(-threshold));
+      root = Tree::join(r, l);
+      shift = (shift - threshold) % max_key;
+
+      hash_combine(hash, Aggregator::get(root));
+    }
+
+    if constexpr (extra_checks) assert_exception(!root, "Root is not null");
+    tree.release_tree(root);
+    if constexpr (extra_checks)
+      assert_exception(tree.used() == 0, "Memory usage is not 0");
+    hash_combine(hash, tree.used());
+
+    timer.stop();
+    return {hash, timer.get_duration()};
+  }
+};
+
+}  // namespace scenario
+}  // namespace bst
+}  // namespace tester

--- a/tester/binary_search_tree/tester.cpp
+++ b/tester/binary_search_tree/tester.cpp
@@ -17,6 +17,7 @@
 #include "tester/binary_search_tree/scenario/insert_remove_node_add_each.h"
 #include "tester/binary_search_tree/scenario/split_join_add_as.h"
 #include "tester/binary_search_tree/scenario/split_join_add_each.h"
+#include "tester/binary_search_tree/scenario/split_join_insert_remove.h"
 
 namespace tester {
 namespace bst {
@@ -58,6 +59,7 @@ bool test(TestType test_type, std::string_view implementation_filter) {
           scenario::InsertRemoveNodeAddAS<DataType::kShuffled>,
           scenario::InsertRemoveNodeAddAS<DataType::kShuffledDuplicates>,
           scenario::InsertAtRemoveAtAddAS<DataType::kRandom>,
+          scenario::SplitJoinInsertRemove<DataType::kRandomDuplicates>,
           scenario::SplitJoinAddEach<DataType::kRandom>,
           scenario::SplitJoinAddAS<DataType::kRandom>>;
 
@@ -77,21 +79,22 @@ bool test(TestType test_type, std::string_view implementation_filter) {
     }
 
     case TestType::kBase: {
-      using Scenarios =
-          std::tuple<scenario::Build<DataType::kIncreasing>,
-                     scenario::Build<DataType::kReverse>,
-                     scenario::Build<DataType::kShuffled>,
-                     scenario::Build<DataType::kShuffledDuplicates>,
-                     scenario::InsertRemove<DataType::kIncreasing>,
-                     scenario::InsertRemove<DataType::kReverse>,
-                     scenario::InsertRemove<DataType::kShuffled>,
-                     scenario::InsertRemove<DataType::kShuffledDuplicates>,
-                     scenario::BuildAddEach<DataType::kShuffled>,
-                     scenario::BuildAddEach<DataType::kShuffledDuplicates>,
-                     scenario::InsertRemoveAddEach<DataType::kIncreasing>,
-                     scenario::InsertRemoveAddEach<DataType::kReverse>,
-                     scenario::InsertRemoveAddEach<DataType::kShuffled>,
-                     scenario::SplitJoinAddEach<DataType::kRandom>>;
+      using Scenarios = std::tuple<
+          scenario::Build<DataType::kIncreasing>,
+          scenario::Build<DataType::kReverse>,
+          scenario::Build<DataType::kShuffled>,
+          scenario::Build<DataType::kShuffledDuplicates>,
+          scenario::InsertRemove<DataType::kIncreasing>,
+          scenario::InsertRemove<DataType::kReverse>,
+          scenario::InsertRemove<DataType::kShuffled>,
+          scenario::InsertRemove<DataType::kShuffledDuplicates>,
+          scenario::BuildAddEach<DataType::kShuffled>,
+          scenario::BuildAddEach<DataType::kShuffledDuplicates>,
+          scenario::InsertRemoveAddEach<DataType::kIncreasing>,
+          scenario::InsertRemoveAddEach<DataType::kReverse>,
+          scenario::InsertRemoveAddEach<DataType::kShuffled>,
+          scenario::SplitJoinInsertRemove<DataType::kRandomDuplicates>,
+          scenario::SplitJoinAddEach<DataType::kRandom>>;
 
       return run_each<
           false, Scenarios, impl::HKF_HPF_AVL, impl::HKF_HPT_AVL,


### PR DESCRIPTION
## Summary
- add split_join_insert_remove scenario exercising random duplicate data
- fix random_dups data generation and rotate split/join by threshold while wrapping keys

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug ..`
- `make -j5`
- `cmake -DCMAKE_BUILD_TYPE=Release ..`
- `make -j5`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_689a0ef168308326a4810017d58cba5e